### PR TITLE
Fix compile with GCC 8.x

### DIFF
--- a/external/miniupnpc/minissdpc.c
+++ b/external/miniupnpc/minissdpc.c
@@ -198,7 +198,7 @@ connectToMiniSSDPD(const char * socketpath)
 		socketpath = "/var/run/minissdpd.sock";
 	memset(&addr, 0, sizeof(addr));
 	addr.sun_family = AF_UNIX;
-	strncpy(addr.sun_path, socketpath, sizeof(addr.sun_path));
+	memcpy(addr.sun_path, socketpath, sizeof(addr.sun_path));
 	/* TODO : check if we need to handle the EINTR */
 	if(connect(s, (struct sockaddr *)&addr, sizeof(struct sockaddr_un)) < 0)
 	{


### PR DESCRIPTION
- Replace strncpy() with memcpy()

Fixes:
external/miniupnpc/minissdpc.c: In function ‘connectToMiniSSDPD’:
external/miniupnpc/minissdpc.c:201:2: error: ‘strncpy’ specified bound 108 equals destination size [-Werror=stringop-truncation]
  strncpy(addr.sun_path, socketpath, sizeof(addr.sun_path));
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [external/miniupnpc/CMakeFiles/upnpc-static.dir/build.make:115: external/miniupnpc/CMakeFiles/upnpc-static.dir/minissdpc.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:149: external/miniupnpc/CMakeFiles/upnpc-static.dir/all] Error 2
make: *** [Makefile:130: all] Error 2