### PR TITLE
Added Cors Policy "HTTP JSON 2.0 RPC Server"

### DIFF
--- a/src/NodeRpcProxy/NodeRpcProxy.cpp
+++ b/src/NodeRpcProxy/NodeRpcProxy.cpp
@@ -795,6 +795,7 @@ std::error_code NodeRpcProxy::jsonRpcCommand(const std::string& method, const Re
     HttpResponse httpRes;
 
     httpReq.setUrl("/json_rpc");
+    httpReq.addHeader("Access-Control-Allow-Origin", "*");
     httpReq.addHeader("Content-Type", "application/json");
     httpReq.setBody(jsReq.getBody());
 

--- a/src/Rpc/HttpClient.h
+++ b/src/Rpc/HttpClient.h
@@ -50,6 +50,7 @@ void invokeJsonCommand(HttpClient& client, const std::string& url, const Request
   HttpResponse hres;
 
   hreq.setUrl(url);
+  hreq.addHeader("Access-Control-Allow-Origin", "*");
   hreq.addHeader("Content-Type", "application/json");
   hreq.setBody(storeToJson(req));
   client.request(hreq, hres);

--- a/src/Rpc/JsonRpc.cpp
+++ b/src/Rpc/JsonRpc.cpp
@@ -32,6 +32,7 @@ void invokeJsonRpcCommand(HttpClient& httpClient, JsonRpcRequest& jsReq, JsonRpc
   HttpResponse httpRes;
 
   httpReq.setUrl("/json_rpc");
+  httpReq.addHeader("Access-Control-Allow-Origin", "*");
   httpReq.addHeader("Content-Type", "application/json");
   httpReq.setBody(jsReq.getBody());
 

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -87,6 +87,7 @@ RpcServer::HandlerFunction jsonMethod(bool (RpcServer::*handler)(typename Comman
     }
 
     bool result = (obj->*handler)(req, res);
+    response.addHeader("Access-Control-Allow-Origin", "*");
     response.addHeader("Content-Type", "application/json");
     response.setBody(storeToJson(res.data()));
     return result;
@@ -155,6 +156,7 @@ bool RpcServer::processJsonRpcRequest(const HttpRequest& request, HttpResponse& 
 
   using namespace JsonRpc;
 
+  response.addHeader("Access-Control-Allow-Origin", "*");
   response.addHeader("Content-Type", "application/json");
 
   JsonRpcRequest jsonRequest;


### PR DESCRIPTION
Add Access-Control-Allow-Origin to the header. This prevents the CORS policy lock error when making a call to the HTTP JSON 2.0 RPC Server.